### PR TITLE
Fix export issue in bond_app_analytics

### DIFF
--- a/packages/app_analytics/lib/bond_app_analytics.dart
+++ b/packages/app_analytics/lib/bond_app_analytics.dart
@@ -2,3 +2,4 @@ library app_analytics;
 
 export 'src/core/analytics_event.dart';
 export 'src/analytics_provider.dart';
+export 'src/core/system_events.dart';


### PR DESCRIPTION
Hi, I noticed that the package of ``app_analytics`` has an issue with file ``bond_app_analytics.dart``:
it doesn't export system_events which is required in flutter_bond project,

Thanks.

``PART OF GTC OPEN SOURCE INTIATIVE``
