### PR TITLE
Fix Dependency Version Issues

### DIFF
--- a/packages/cache/pubspec.yaml
+++ b/packages/cache/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
   flutter:
     sdk: flutter
   bond_core: ^0.0.1+1
-  shared_preferences: ^2.1.2
+  shared_preferences: any

--- a/packages/chat_bot/pubspec.yaml
+++ b/packages/chat_bot/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
   flutter:
     sdk: flutter
 
-  delayed_display: ^2.0.0
+  delayed_display: any
   bond_network: ^0.0.1

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -9,6 +9,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  device_info: ^2.0.3
-  get_it: ^7.2.0
+  device_info: any
+  get_it: any
 

--- a/packages/form/pubspec.yaml
+++ b/packages/form/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.8.0
-  riverpod: ^2.3.6
-  intl: ^0.18.0
+  meta: any
+  riverpod: any
+  intl: any
 
   bond_core: ^0.0.1

--- a/packages/network/pubspec.yaml
+++ b/packages/network/pubspec.yaml
@@ -9,14 +9,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dio: ^5.2.1+1
-  equatable: ^2.0.5
-  json_annotation: ^4.7.0
-  json_serializable: ^6.5.4
-  meta: ^1.8.0
-  shared_preferences: ^2.1.2
-  package_info_plus: ^4.0.2
-  faker: ^2.0.0
+  dio: any
+  equatable: any
+  json_annotation: any
+  json_serializable: any
+  meta: any
+  shared_preferences: any
+  package_info_plus: any
+  faker: any
 
   bond_core: ^0.0.1+1
   bond_cache: ^0.0.1+1

--- a/packages/notifications/pubspec.yaml
+++ b/packages/notifications/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  json_annotation: ^4.7.0
-  json_serializable: ^6.5.4
+  json_annotation: any
+  json_serializable: any
   bond_core: ^0.0.1+1
   bond_network: ^0.0.1
 


### PR DESCRIPTION
This pull request aims to address dependency version conflicts encountered when integrating the Bond package into an existing Flutter application. Currently, there are conflicts related to the intl package versions.

For instance, the application is currently using ` intl: ^0.17.0`, but when fetching the bond_form package, it requires a dependency on `intl `with a minimum version of `^0.18.0`.

This pull request proposes the necessary changes to ensure compatibility between the application's intl version and the required version specified by the `bond_form` package. By resolving these dependency conflicts, we can successfully integrate the Bond package into the application without compromising functionality or stability.

Your review and feedback on this pull request are greatly appreciated.

> PART OF GTC OPEN SOURCE INITIATIVE
