### PR TITLE
feat(form-transformers): Add field transformation functionality

### DIFF
--- a/packages/form/CHANGELOG.md
+++ b/packages/form/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Changelog
 
+## 0.0.2
+
+* Automatic Body Generation with BodyConvertible Mixin
+•	Introduced the BodyConvertible mixin, which allows automatic generation of a request body map from form state values. This simplifies the process of extracting and transforming form field values into a key-value map suitable for API requests.
+•	The body() method automatically iterates over all form fields, applying registered transformers to generate the body map.
+
+* Flexible Field Transformers with TransformersRegistry
+  •	Added the TransformersRegistry class, which allows developers to register custom field transformers. These transformers can convert field values into any desired format, such as converting enum values to strings.
+  •	The registry supports both single values and collections (e.g., Set, List), automatically handling the transformation of collection elements.
+
 ## 0.0.1+30
 * update dependence
 

--- a/packages/form/lib/bond_form.dart
+++ b/packages/form/lib/bond_form.dart
@@ -10,3 +10,5 @@ export 'src/form_fields.dart';
 export 'src/form_fields/form_field_state.dart';
 export 'src/validation/has_validation_errors.dart';
 export 'src/validation/rules.dart';
+export 'src/form_transformers/body_convertible.dart';
+export 'src/form_transformers/transformers_registry.dart';

--- a/packages/form/lib/src/form_transformers/body_convertible.dart
+++ b/packages/form/lib/src/form_transformers/body_convertible.dart
@@ -1,0 +1,47 @@
+import 'package:bond_form/bond_form.dart';
+
+import 'transformers_registry.dart';
+
+/// A mixin that adds functionality to convert form state into a
+/// map of key-value pairs suitable for creating a request body.
+mixin BodyConvertible<Success, Failure extends Error>
+    on FormController<Success, Error> {
+  /// Generates a map from the form state, applying any transformations
+  /// specified by the `fieldTransformers` method.
+  ///
+  /// This method iterates over all fields in the form state, applies
+  /// any registered transformers, and returns a map suitable for use
+  /// as a request body.
+  ///
+  /// Returns: A `Map<String, dynamic>` containing the transformed form data.
+  Map<String, dynamic> body() {
+    final _registry = TransformersRegistry();
+    fieldTransformers(_registry);
+
+    final map = <String, dynamic>{};
+
+    // Iterate through each field in the fields map
+    state.fields.forEach((fieldName, fieldState) {
+      final fieldValue = fieldState.value;
+      final newValue = _registry.transform(fieldValue);
+      if (newValue != null) {
+        map[fieldName] = newValue;
+      } else {
+        map[fieldName] = fieldValue;
+      }
+    });
+
+    return map;
+  }
+
+  /// Registers transformers for specific field types.
+  ///
+  /// Subclasses should implement this method to register any custom
+  /// transformers needed to convert field values to the appropriate
+  /// types for the request body.
+  ///
+  /// Parameters:
+  ///   - [registry]: The `TransformersRegistry` instance where
+  ///                 transformers should be registered.
+  void fieldTransformers(TransformersRegistry registry);
+}

--- a/packages/form/lib/src/form_transformers/field_transformer.dart
+++ b/packages/form/lib/src/form_transformers/field_transformer.dart
@@ -1,0 +1,27 @@
+/// A typedef representing a function that transforms a field value
+/// from one type to another.
+///
+/// Parameters:
+///   - [T] The input type (the original field value).
+///   - [G] The output type (the transformed value).
+typedef FieldTransformer<T, G extends Object> = G Function(T value);
+
+/// A factory class that wraps a transformation function, allowing
+/// it to be used within the `TransformersRegistry`.
+class FieldTransformerFactory<T, G extends Object> {
+  final FieldTransformer<T, G> transformationFunction;
+
+  FieldTransformerFactory({
+    required this.transformationFunction,
+  });
+
+  /// Transforms a value using the wrapped transformation function.
+  ///
+  /// Parameters:
+  ///   - [value] The value to be transformed.
+  ///
+  /// Returns: The transformed value.
+  G transform(dynamic value) {
+    return transformationFunction.call(value as T);
+  }
+}

--- a/packages/form/lib/src/form_transformers/transformers_registry.dart
+++ b/packages/form/lib/src/form_transformers/transformers_registry.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+import 'field_transformer.dart';
+
+/// A registry for managing field transformers, allowing custom
+/// transformations of form field values based on their types.
+class TransformersRegistry {
+  final factories = <Type, FieldTransformerFactory<dynamic, Object>>{};
+
+  /// Registers a transformer function for a specific field type.
+  ///
+  /// Parameters:
+  ///   - [T] The type of the field value that the transformer handles.
+  ///   - [G] The type that the field value should be transformed into.
+  ///   - [transformationFunction] The function that performs the transformation.
+  void register<T, G extends Object>(
+    FieldTransformer<T, G> transformationFunction,
+  ) {
+    final fieldTransformerFactory = FieldTransformerFactory<T, G>(
+      transformationFunction: transformationFunction,
+    );
+    factories[T] = fieldTransformerFactory;
+  }
+
+  /// Transforms a field value using the appropriate transformer
+  /// registered for its type.
+  ///
+  /// Parameters:
+  ///   - [value] The field value to be transformed.
+  ///
+  /// Returns: The transformed value, or the original value if no transformer
+  /// is registered for its type.
+  dynamic transform(dynamic value) {
+    final transformer = factories[value.runtimeType];
+
+    // If no transformer is found, check if there is a transformer for the base type
+    if (transformer == null && value is Iterable) {
+      // Handle cases where the runtime type might be a collection type like Set or List
+      if (value is Set) {
+        return _transformCollection<Set>(value);
+      } else if (value is List) {
+        return _transformCollection<List>(value);
+      }
+    }
+    return transformer?.transform(value);
+  }
+
+  /// Transforms a collection of values using the appropriate transformer
+  /// registered for the type of elements in the collection.
+  ///
+  /// Parameters:
+  ///   - [C] The type of the collection (e.g., Set, List).
+  ///   - [collection] The collection of values to be transformed.
+  ///
+  /// Returns: A JSON-encoded string of the transformed collection.
+  dynamic _transformCollection<C extends Iterable>(C collection) {
+    final firstElementType =
+        collection.isNotEmpty ? collection.first.runtimeType : null;
+    if (firstElementType != null) {
+      final transformer = factories[firstElementType];
+      if (transformer != null) {
+        return jsonEncode(
+          collection.map((item) => transformer.transform(item)).toList(),
+        );
+      }
+    }
+    return collection;
+  }
+}

--- a/packages/form/packages/bond_form_riverpod/example/lib/features/pizza/presentations/providers/pizza_provider.dart
+++ b/packages/form/packages/bond_form_riverpod/example/lib/features/pizza/presentations/providers/pizza_provider.dart
@@ -16,10 +16,10 @@ enum Toppings {
   blackOlives
 }
 
-enum Branches { main, gaza, cairo }
+ enum Branches { main, gaza, cairo }
 
 class PizzaOrderFormController
-    extends AutoDisposeFormStateNotifier<String, Error> {
+    extends AutoDisposeFormStateNotifier<String, Error> with BodyConvertible {
   // bond create form widget -- PizzaOrderFormController
 
   @override
@@ -110,6 +110,14 @@ class PizzaOrderFormController
       };
 
   @override
+  void fieldTransformers(TransformersRegistry registry) {
+    registry.register<Branches, String>((value) => value.name);
+    registry.register<CrustType, String>((value) => value.name);
+    registry.register<PizzaSize, String>((value) => value.name);
+    registry.register<Toppings, String>((value) => value.name);
+  }
+
+  @override
   Future<String> onSubmit() async {
     // on summit called after the for validation is successful
     // so we can access the values through required helper methods.
@@ -127,6 +135,10 @@ class PizzaOrderFormController
     final specialInstructions =
         state.textFieldValue('specialInstructions') ?? 'None';
 
+    // or use body method to create body map with key and value that are suitable to send to api request
+
+    //final bodyContent = body();
+
     // Normally, you'd send these values to an API or a database here.
     // For demonstration, we'll just return a summary string.
     return Future.delayed(
@@ -138,7 +150,8 @@ class PizzaOrderFormController
         Branch: $branch
         Pizza Size: $pizzaSize
         Crust Type: $crustType
-        Toppings: $toppings
+        Toppings: 
+        $toppings
         Include Sides: $includeSides
         Special Instructions: $specialInstructions
       ''';

--- a/packages/form/packages/bond_form_riverpod/example/pubspec.lock
+++ b/packages/form/packages/bond_form_riverpod/example/pubspec.lock
@@ -22,7 +22,7 @@ packages:
       path: "../../.."
       relative: true
     source: path
-    version: "0.0.1+29"
+    version: "0.0.1+30"
   bond_form_riverpod:
     dependency: "direct main"
     description:

--- a/packages/form/packages/bond_form_riverpod/example/pubspec.yaml
+++ b/packages/form/packages/bond_form_riverpod/example/pubspec.yaml
@@ -13,8 +13,10 @@ dependencies:
     sdk: flutter
 
   # Bond packages
-  bond_core: ^0.0.1+7
-  bond_form: ^0.0.1
+  bond_core:
+    path: ../../../../core
+  bond_form:
+    path: ../../../../form
   bond_form_riverpod:
     path: ../../bond_form_riverpod
 

--- a/packages/form/pubspec.yaml
+++ b/packages/form/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bond_form
 description: Form is a Bond package provides a convenient way to handle Form.
-version: 0.0.1+30
+version: 0.0.2
 homepage: https://github.com/onestudio-co/flutter-bond
 repository: https://github.com/onestudio-co/bond-core/tree/main/packages/form
 
@@ -14,7 +14,7 @@ dependencies:
   mime: ^1.0.5
   intl: ^0.19.0
 
-  bond_core: ^0.0.1
+  bond_core: ^0.0.2
 
 
 dev_dependencies:


### PR DESCRIPTION

### Automatic Request Body Generation with `BodyConvertible`

#### Overview

The `BodyConvertible` mixin simplifies the process of extracting and transforming form field values into a format suitable for API requests. By implementing this mixin, you can automatically generate a map of key-value pairs representing the form state, which can be directly used as a request body.

#### How It Works

When you mix `BodyConvertible` into your form controller, it provides a `body()` method that generates a map from the form state. This method iterates over all form fields, applying any custom transformers you've registered, and returns a map that can be sent directly to an API or used elsewhere in your application.

#### Key Components

- **`body()` Method**: Generates a map from the form state, applying any necessary transformations to field values.
- **`TransformersRegistry`**: Allows you to register custom transformers for specific field types, converting them into the appropriate format for the request body.
- **Custom Transformers**: You can register transformers to handle specific types of form field values, such as converting enums to strings or serializing collections like `Set` or `List`.

#### Usage Example

Here's a basic example of how to use `BodyConvertible` in your form controller:

```dart
import 'body_convertible.dart';
import 'transformers_registry.dart';
import 'field_transformer.dart';

class PizzaOrderFormController extends AutoDisposeFormStateNotifier<String, Error>
    with BodyConvertible<String, Error> {

  @override
  void fieldTransformers(TransformersRegistry registry) {
    registry.register<CrustType, String>((CrustType value) => value.name);
    registry.register<PizzaSize, String>((value) => value.name ?? '');
    registry.register<Set<Toppings>, String>(
      (value) => value.map((value) => value.name).join(','),
    );
  }

  @override
  Future<String> onSubmit() async {
    // Generate the body map using the body() method
    final bodyData = body();

    // Use the generated body data for an API request or further processing
    return Future.delayed(
      const Duration(seconds: 2),
      () {
        return '''
          Customer Name: ${bodyData['customerName']}
          Phone Number: ${bodyData['phoneNumber']}
          Branch: ${bodyData['branch']}
          Pizza Size: ${bodyData['pizzaSize']}
          Crust Type: ${bodyData['crustType']}
          Toppings: ${bodyData['toppings']}
          Include Sides: ${bodyData['includeSides']}
          Special Instructions: ${bodyData['specialInstructions']}
        ''';
      },
    );
  }
}
```

#### Registering Transformers

To ensure the `body()` method correctly transforms your form field values, you need to register custom transformers in the `fieldTransformers()` method of your form controller. Here's an example:

```dart
@Override
void fieldTransformers(TransformersRegistry registry) {
  registry.register<CrustType, String>((CrustType value) => value.name);
  registry.register<PizzaSize, String>((value) => value.name ?? '');
  registry.register<Set<Toppings>, String>(
    (value) => value.map((value) => value.name).join(','),
  );
}
```

#### Benefits

- **Simplified Code**: Reduces boilerplate by automatically handling form field extraction and transformation.
- **Flexible Transformation**: Easily convert complex data types into formats suitable for API requests using custom transformers.
- **Reusability**: The `BodyConvertible` mixin can be reused across different form controllers, making it a versatile tool in your toolkit.

#### Conclusion

The `BodyConvertible` mixin streamlines the process of generating request bodies from form state, making it easier to work with complex forms in your Bond Form-based applications. By using the `body()` method and registering necessary transformers, you can efficiently prepare data for submission to APIs or other external services.

