### PR TITLE
modify regex to include multiple subdomains

### DIFF
--- a/packages/form/lib/src/validation/rules/email.dart
+++ b/packages/form/lib/src/validation/rules/email.dart
@@ -17,6 +17,6 @@ class Email extends ValidationRule<String> {
 
   @override
   bool validate(String value, Map<String, FormFieldState> fields) {
-    return RegExp(r'^.+@[a-zA-Z]+\.[a-zA-Z]+(\.?[a-zA-Z]+)$').hasMatch(value);
+    return RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$').hasMatch(value);
   }
 }


### PR DESCRIPTION
Explanation:

- ^[a-zA-Z0-9._%+-]+: Matches the local part of the email (before the @).
- @[a-zA-Z0-9.-]+: Matches the domain part (allows subdomains and hyphens).
- \.[a-zA-Z]{2,}$: Matches the top-level domain (TLD), ensuring it's at least two characters long.

This updated regex should correctly validate emails like hamd.wal@uae.o5e.com.