### PR TITLE
chore: update dependencies and version to 0.0.3

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Changelog
 
+## 0.0.3
+
+### Changes
+
+- **Dependency Update**:
+    - Bumped `get_it` from `^7.6.4` to `^8.0.3`.
+
+> **Note**: This update should be seamless if you aren’t using any breaking changes introduced in `get_it` 8.0. However, if you rely on advanced `get_it` features, consult the official `get_it` documentation to ensure compatibility with the new version.
+
 ## 0.0.2
 
 ### Migration Guide

--- a/packages/core/pubspec.lock
+++ b/packages/core/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -34,31 +34,31 @@ packages:
     dependency: "direct main"
     description:
       name: get_it
-      sha256: f79870884de16d689cf9a7d15eedf31ed61d750e813c538a6efb92660fea83c3
+      sha256: f126a3e286b7f5b578bf436d5592968706c4c1de28a228b870ce375d9f743103
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.4"
+    version: "8.0.3"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   vector_math:
     dependency: transitive
     description:
@@ -68,4 +68,4 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bond_core
 description: Bond Core Foundational Library for the Flutter Bond framework.
-version: 0.0.2
+version: 0.0.3
 repository: https://github.com/onestudio-co/bond-core/tree/main/packages/core
 homepage: https://github.com/onestudio-co/flutter-bond
 
@@ -10,5 +10,5 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  get_it: ^7.6.4
+  get_it: ^8.0.3
 


### PR DESCRIPTION
Bump `get_it` from `^7.6.4` to `^8.0.3` and update other 
dependencies in `pubspec.yaml` and `pubspec.lock`. 
Update the package version to `0.0.3` in `pubspec.yaml`. 
This ensures compatibility with the latest features and 
improvements in the dependencies.