### PR TITLE
chore: update async package and increment version

### DIFF
--- a/packages/cache/CHANGELOG.md
+++ b/packages/cache/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.4+1
+- **dev_dependencies:** Updated the `async` package to `^2.13.0` to resolve package validation warnings.
+
 ## 0.0.4
 
 ### Changed

--- a/packages/cache/pubspec.lock
+++ b/packages/cache/pubspec.lock
@@ -31,13 +31,13 @@ packages:
     source: hosted
     version: "2.4.2"
   async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.0"
   bond_core:
     dependency: "direct main"
     description:

--- a/packages/cache/pubspec.yaml
+++ b/packages/cache/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bond_cache
 description: Cache is a Bond package provides a convenient way to handle caching in app.
-version: 0.0.4
+version: 0.0.4+1
 homepage: https://github.com/onestudio-co/flutter-bond
 repository: https://github.com/onestudio-co/bond-core/tree/main/packages/cache
 
@@ -17,3 +17,4 @@ dependencies:
 dev_dependencies:
   test: ^1.25.15
   mockito: ^5.4.5
+  async: ^2.13.0


### PR DESCRIPTION
Updates the `async` package to version `^2.13.0` in the 
development dependencies to resolve package validation warnings. 
Increments the version to `0.0.4+1` to reflect this change.