### PR TITLE
chore: update dependencies and version for bond_form

### DIFF
--- a/packages/form/CHANGELOG.md
+++ b/packages/form/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Changelog
 
+## 0.0.4
+
+### Changed
+- **meta:** Upgraded from `^1.8.0` to `^1.15.0`.
+- **mime:** Upgraded from `^1.0.5` to `^2.0.0`.
+- **intl:** Upgraded from `^0.19.0` to `^0.20.2`.
+- **bond_core:** Upgraded from `^0.0.2` to `^0.0.3`.
+
 ## 0.0.3+1 
 - Introduced BaseFormController mixin to handle common form state logic and provide reusable form management functions.
 

--- a/packages/form/pubspec.lock
+++ b/packages/form/pubspec.lock
@@ -36,10 +36,11 @@ packages:
   bond_core:
     dependency: "direct main"
     description:
-      path: "../core"
-      relative: true
-    source: path
-    version: "0.0.2"
+      name: bond_core
+      sha256: dfca71a97c29be674f73463acd75d9e228aec8e82cfae5a4a596dde37b152b78
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
   characters:
     dependency: transitive
     description:
@@ -60,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
@@ -105,10 +106,10 @@ packages:
     dependency: transitive
     description:
       name: get_it
-      sha256: f79870884de16d689cf9a7d15eedf31ed61d750e813c538a6efb92660fea83c3
+      sha256: f126a3e286b7f5b578bf436d5592968706c4c1de28a228b870ce375d9f743103
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.4"
+    version: "8.0.3"
   glob:
     dependency: transitive
     description:
@@ -121,42 +122,42 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   intl_translation:
     dependency: "direct dev"
     description:
       name: intl_translation
-      sha256: b858d88b569f3c529e992ba7186aa495f3e862897df60edb932563c619943610
+      sha256: b3f1ebfab4109d1a946b45c57523628da92a0e2a2df5f2d9981ef4334fd24a26
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.0"
+    version: "0.20.1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: "direct main"
     description:
       name: mime
-      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
@@ -185,7 +186,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -243,4 +244,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0-0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"

--- a/packages/form/pubspec.yaml
+++ b/packages/form/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bond_form
 description: Form is a Bond package provides a convenient way to handle Form.
-version: 0.0.3+2
+version: 0.0.4
 homepage: https://github.com/onestudio-co/flutter-bond
 repository: https://github.com/onestudio-co/bond-core/tree/main/packages/form
 
@@ -10,11 +10,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.8.0
-  mime: ^1.0.5
-  intl: ^0.19.0
+  meta: ^1.15.0
+  mime: ^2.0.0
+  intl: ^0.20.2
 
-  bond_core: ^0.0.2
+  bond_core: ^0.0.3
 
 
 dev_dependencies:


### PR DESCRIPTION
Upgrade dependencies in `pubspec.yaml` to their latest versions, 
including `meta`, `mime`, `intl`, and `bond_core`. Update the 
version of the package to `0.0.4` and reflect these changes in 
`pubspec.lock`. Update the changelog to document these changes.