### PR TITLE
feat: update Dart SDK constraint to support Dart 3

### DIFF
--- a/packages/app_analytics/CHANGELOG.md
+++ b/packages/app_analytics/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0
+
+### Breaking Changes
+- **Environment SDK Constraint:** Updated from `>=2.16.0 <3.0.0` to `>=3.0.0 <4.0.0` to support Dart 3. Users on Dart 2.x will need to upgrade.
+
 ## 0.0.1+3
 
 * send AnalyticsEvent to customer event methods.

--- a/packages/app_analytics/pubspec.lock
+++ b/packages/app_analytics/pubspec.lock
@@ -2,4 +2,4 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=2.16.0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/packages/app_analytics/pubspec.yaml
+++ b/packages/app_analytics/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bond_app_analytics
 description: Bond package provides a convenient way to log analytics events
-version: 0.0.1+3
+version: 0.1.0
 homepage: https://github.com/onestudio-co/flutter-bond
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Updates the Dart SDK constraint in `pubspec.yaml` and `pubspec.lock` 
from `>=2.16.0 <3.0.0` to `>=3.0.0 <4.0.0` to support Dart 3. 
Increments the version to `0.1.0` in `pubspec.yaml` and adds a 
breaking change note in `CHANGELOG.md` to inform users of the 
required upgrade from Dart 2.x.